### PR TITLE
Addresses #97 implementing DNS challenge for SSL

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,47 +1,39 @@
 {
-#    debug
-   email edropswebsite@gmail.com
-#   acme_ca https://acme-staging-v02.api.letsencrypt.org/directory
-}
-
-www.edrops.org {
-    redir https://www.edroplets.org{uri}
-}
-
-edrops.org {
-    redir https://edroplets.org{uri}
+        # debug
+        email edropswebsite@gmail.com
+        # acme_ca https://acme-staging-v02.api.letsencrypt.org/directory
 }
 
 www.edroplets.org {
-   redir https://edroplets.org{uri}
-}
-
-edroplets.org {
-    log {
-        output stdout
-    }
-    encode gzip
-
-    @frontendApi {
-        not {
-            path /api/*
+        tls {
+                dns godaddy {env.GODADDY_TOKEN}
         }
-    }
-    
-    @try_files {
-        not path /api/*
-        file {
-            try_files {path} {path}/ /index.html
+
+        log {
+                output stdout
         }
-    }
-    rewrite @try_files {http.matchers.file.relative}
+        encode gzip
 
-    handle_path /api/* {
-        reverse_proxy edrop_backend:3000
-    }
+        @frontendApi {
+                not {
+                        path /api/*
+                }
+        }
 
-    root * /usr/share/caddy/www
-    file_server @frontendApi
+        @try_files {
+                not path /api/*
+                file {
+                        try_files {path} {path}/ /index.html
+                }
+        }
+        rewrite @try_files {http.matchers.file.relative}
+
+        handle_path /api/* {
+                reverse_proxy edrop_backend:3000
+        }
+
+        root * /usr/share/caddy/www
+        file_server @frontendApi
 }
 
 # community.edroplets.org {
@@ -55,7 +47,7 @@ edroplets.org {
 #             path /api/*
 #         }
 #     }
-    
+
 #     @try_files {
 #         not path /api/*
 #         file {

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM caddy:builder AS builder
+
+RUN xcaddy build \
+    --with github.com/caddy-dns/godaddy \
+    --with github.com/caddyserver/caddy/v2=github.com/caddyserver/caddy/v2@v2.6.3
+
+FROM caddy:latest
+
+COPY --from=builder /usr/bin/caddy /usr/bin/caddy

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -10,7 +10,11 @@ services:
       - edrop_caddy
   
   edrop_caddy:
-    image: caddy:2.3.0
+    build: 
+      context: .
+      dockerfile: Dockerfile
+    env_file:
+      - ./deploy/prod/caddy.env
     container_name: edrop_caddy
     restart: unless-stopped
     ports:
@@ -25,4 +29,5 @@ services:
 
 volumes:
   caddy_data:
+    external: true
   caddy_config:


### PR DESCRIPTION
Custom Caddy docker image that adds the GoDaddy DNS Caddy module. See https://github.com/caddy-dns/godaddy
Now our server can complete the SSL challenge with DNS, which should be much easier.